### PR TITLE
FOLIO-398 tidy 1

### DIFF
--- a/ramls/calendar.raml
+++ b/ramls/calendar.raml
@@ -66,7 +66,7 @@ schemas:
             type: boolean
             description: Include past openings in response. Default false.
             required: false
-        description: List regular library hours period. The default response contains the period names and it's dates.
+        description: List regular library hours period. The default response contains the period names and its dates.
         responses:
           200:
             body:


### PR DESCRIPTION
Fix typo. This is possessive its. Search “It’s not its”

This merge is also to test the updated API docs generation facility.