### PR TITLE
MODCAL-35 Error saving an exceptional period

### DIFF
--- a/src/main/java/org/folio/rest/impl/CalendarAPI.java
+++ b/src/main/java/org/folio/rest/impl/CalendarAPI.java
@@ -106,17 +106,17 @@ public class CalendarAPI implements Calendar {
       -> postgresClient.startTx(beginTx
         -> postgresClient.get(beginTx, OPENINGS, Openings.class, criterionForId, true, false, resultOfSelectOpenings -> {
         if (resultOfSelectOpenings.failed()) {
-          asyncResultHandler.handle(Future.succeededFuture(
+          postgresClient.endTx(beginTx,end -> asyncResultHandler.handle(Future.succeededFuture(
             PostCalendarPeriodsPeriodByServicePointIdResponse.respond500WithTextPlain(
-              "Error while listing events.")));
+              "Error while listing events."))));
         } else if (resultOfSelectOpenings.result().getResults().isEmpty()) {
           PostCalendarPeriodsRequestParams postCalendarPeriodsRequestParams = new PostCalendarPeriodsRequestParams(lang, entity, isExceptional, openingsTable);
           postgresClient.save(beginTx, OPENINGS, openingsTable, replyOfSavingOpenings
             -> saveRegularHours(postCalendarPeriodsRequestParams, postgresClient, asyncResultHandler, beginTx, replyOfSavingOpenings));
         } else {
-          asyncResultHandler.handle(Future.succeededFuture(
+          postgresClient.endTx(beginTx,end -> asyncResultHandler.handle(Future.succeededFuture(
             PostCalendarPeriodsPeriodByServicePointIdResponse.respond500WithTextPlain(
-              "Intervals can not overlap.")));
+              "Intervals can not overlap."))));
         }
       })
       )


### PR DESCRIPTION
### Purpose
Fix the bug in `mod-calendar`

### Approach
1. closed PGclient transaction when an error occurred while updating and saving the exceptional period
2. added test for an exceptional period

### Link 
[MODCAL-35](https://issues.folio.org/browse/MODCAL-35)
