### PR TITLE
MODCAL-45 Split permissions by http method

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "provides": [
     {
       "id": "calendar",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -17,25 +17,46 @@
         },
         {
           "methods": [
-            "GET",
-            "POST"
+            "GET"
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period",
           "permissionsRequired": [
-            "calendar.collection.add",
             "calendar.collection.get"
           ]
         },
         {
           "methods": [
-            "GET",
-            "DELETE",
+            "POST"
+          ],
+          "pathPattern": "/calendar/periods/{servicePointId}/period",
+          "permissionsRequired": [
+            "calendar.collection.add"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/calendar/periods/{servicePointId}/period/{periodId}",
+          "permissionsRequired": [
+            "calendar.collection.get"
+          ]
+        },
+        {
+          "methods": [
             "PUT"
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period/{periodId}",
           "permissionsRequired": [
-            "calendar.collection.get",
-            "calendar.collection.update",
+            "calendar.collection.update"
+          ]
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/calendar/periods/{servicePointId}/period/{periodId}",
+          "permissionsRequired": [
             "calendar.collection.remove"
           ]
         },
@@ -49,13 +70,17 @@
           ]
         }
       ]
-    },{
+    },
+    {
       "id": "_tenant",
       "version": "1.0",
       "interfaceType": "system",
       "handlers": [
         {
-          "methods" : [ "POST", "DELETE" ],
+          "methods": [
+            "POST",
+            "DELETE"
+          ],
           "pathPattern": "/_/tenant"
         }
       ]
@@ -99,8 +124,16 @@
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {
-      "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }
+      "HostConfig": {
+        "PortBindings": {
+          "8081/tcp": [
+            {
+              "HostPort": "%p"
+            }
+          ]
+        }
+      }
     },
-    "dockerPull" : false
+    "dockerPull": false
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -13,7 +13,7 @@
           ],
           "pathPattern": "/calendar/periods",
           "permissionsRequired": [
-            "calendar.collection.get"
+            "calendar.opening-hours.collection.get"
           ]
         },
         {
@@ -22,7 +22,7 @@
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period",
           "permissionsRequired": [
-            "calendar.collection.get"
+            "calendar.periods.collection.get"
           ]
         },
         {
@@ -31,7 +31,7 @@
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period",
           "permissionsRequired": [
-            "calendar.collection.add"
+            "calendar.periods.item.post"
           ]
         },
         {
@@ -40,7 +40,7 @@
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period/{periodId}",
           "permissionsRequired": [
-            "calendar.collection.get"
+            "calendar.periods.item.get"
           ]
         },
         {
@@ -49,7 +49,7 @@
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period/{periodId}",
           "permissionsRequired": [
-            "calendar.collection.update"
+            "calendar.periods.item.put"
           ]
         },
         {
@@ -58,7 +58,7 @@
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/period/{periodId}",
           "permissionsRequired": [
-            "calendar.collection.remove"
+            "calendar.periods.item.delete"
           ]
         },
         {
@@ -67,7 +67,7 @@
           ],
           "pathPattern": "/calendar/periods/{servicePointId}/calculateopening",
           "permissionsRequired": [
-            "calendar.collection.get"
+            "calendar.opening-hours.collection.get"
           ]
         }
       ]
@@ -89,34 +89,46 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "calendar.collection.get",
-      "displayName": "List calendar event descriptions",
+      "permissionName": "calendar.opening-hours.collection.get",
+      "displayName": "List calendar opening hours",
       "description": ""
     },
     {
-      "permissionName": "calendar.collection.add",
-      "displayName": "Add new calendar event description",
+      "permissionName": "calendar.periods.collection.get",
+      "displayName": "List calendar periods descriptions",
       "description": ""
     },
     {
-      "permissionName": "calendar.collection.update",
-      "displayName": "Update existing calendar event description",
+      "permissionName": "calendar.periods.item.get",
+      "displayName": "Get period description",
       "description": ""
     },
     {
-      "permissionName": "calendar.collection.remove",
-      "displayName": "Remove calendar event description",
+      "permissionName": "calendar.periods.item.post",
+      "displayName": "Add new calendar period description",
       "description": ""
     },
     {
-      "permissionName": "calendar.collection.all",
-      "displayName": "Calendar permissions",
+      "permissionName": "calendar.periods.item.put",
+      "displayName": "Update existing calendar period description",
+      "description": ""
+    },
+    {
+      "permissionName": "calendar.periods.item.delete",
+      "displayName": "Remove calendar period description",
+      "description": ""
+    },
+    {
+      "permissionName": "calendar.all",
+      "displayName": "Calendar - all permissions",
       "description": "All permission for mod-calendar module",
       "subPermissions": [
-        "calendar.collection.get",
-        "calendar.collection.add",
-        "calendar.collection.update",
-        "calendar.collection.remove"
+        "calendar.opening-hours.collection.get",
+        "calendar.periods.collection.get",
+        "calendar.periods.item.post",
+        "calendar.periods.item.get",
+        "calendar.periods.item.put",
+        "calendar.periods.item.delete"
       ],
       "visible": true
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -128,16 +128,8 @@
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {
-      "HostConfig": {
-        "PortBindings": {
-          "8081/tcp": [
-            {
-              "HostPort": "%p"
-            }
-          ]
-        }
-      }
+      "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }
     },
-    "dockerPull": false
+    "dockerPull" : false
   }
 }

--- a/ramls/calendar.raml
+++ b/ramls/calendar.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Calendar
-version: v2.0
+version: v3.0
 baseUri: https://github.com/folio-org/mod-calendar
 
 documentation:


### PR DESCRIPTION
## Purpose
Resolves: [MODCAL-45](https://issues.folio.org/browse/MODCAL-45)
Split permissions by HTTP method in module descriptor
Corresponding pull requests:

- https://github.com/folio-org/mod-circulation/pull/284
- https://github.com/folio-org/ui-calendar/pull/194