### PR TITLE
deploy to kubernetes when master/release

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ buildMvn {
   publishAPI = 'yes'
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
+  doKubeDeploy = true
 
   doDocker = {
     buildJavaDocker {


### PR DESCRIPTION
Turn on doKubeDeploy option to deploy container to Kubernetes ci environment when snapshot or release.