### PR TITLE
MODCAL-49 add validation for overlapping of exceptional periods

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.2</version>
+        <version>2.9.10</version>
       </dependency>
 
       <dependency>

--- a/src/main/java/org/folio/rest/service/OpeningsService.java
+++ b/src/main/java/org/folio/rest/service/OpeningsService.java
@@ -20,5 +20,5 @@ public interface OpeningsService {
 
   Future<Void> deleteOpeningsById(AsyncResult<SQLConnection> conn, String openingsId);
 
-  Future<Void> checkOpeningsForOverlap(AsyncResult<SQLConnection> conn, Openings openings);
+  Future<Void> checkOpeningsForOverlap(AsyncResult<SQLConnection> conn, Openings openings, boolean isUpdate);
 }

--- a/src/test/java/org/folio/rest/impl/CalendarIT.java
+++ b/src/test/java/org/folio/rest/impl/CalendarIT.java
@@ -67,7 +67,7 @@ public class CalendarIT {
   private static Vertx vertx;
 
   @Rule
-  public Timeout rule = Timeout.seconds(500);
+  public Timeout rule = Timeout.seconds(60);
 
   @BeforeClass
   public static void setup(TestContext context) {

--- a/src/test/java/org/folio/rest/impl/CalendarIT.java
+++ b/src/test/java/org/folio/rest/impl/CalendarIT.java
@@ -67,7 +67,7 @@ public class CalendarIT {
   private static Vertx vertx;
 
   @Rule
-  public Timeout rule = Timeout.seconds(60);
+  public Timeout rule = Timeout.seconds(500);
 
   @BeforeClass
   public static void setup(TestContext context) {


### PR DESCRIPTION
## Purpose
Add validation  to avoid overlap of exceptional periods.  To not allow user create or update exceptional periods with overlapping existing.

Resolves story: https://issues.folio.org/browse/MODCAL-49

## Approach 
- implement validation for creation or update periods to calendar
- implement tests for testing all possible options of overlapping

## Links
https://issues.folio.org/browse/MODCAL-49