### PR TITLE
UICAL-90 Remove UI permission Calendar: All permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -130,7 +130,7 @@
         "calendar.periods.item.put",
         "calendar.periods.item.delete"
       ],
-      "visible": true
+      "visible": false
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
**Purpose**
Remove redundant permission.

**Approach**
Toggle visibility flag for permission 'calendar.all' in module descriptor.

**Link**
[UICAL-90](https://issues.folio.org/browse/UICAL-90)