### PR TITLE
MODCAL-54: Update jackson to 2.10.0, fixes jackson-databind security.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <folio.domain-models-runtime.version>24.0.0</folio.domain-models-runtime.version>
 
     <vertx.version>3.5.4</vertx.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.10.0</jackson.version>
 
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
 
@@ -90,39 +90,11 @@
       </dependency>
 
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.2</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-json-provider</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.jaxrs</groupId>
-        <artifactId>jackson-jaxrs-base</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>com.fasterxml.jackson.dataformat</groupId>
-        <artifactId>jackson-dataformat-yaml</artifactId>
-        <version>${jackson.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
The update fixes two polymorphic typing issues that are security vulnerabilities:

* https://nvd.nist.gov/vuln/detail/CVE-2019-16335
* https://nvd.nist.gov/vuln/detail/CVE-2019-14540

Switch to jackson-bom.

This check shows that it jackson-databind 2.10.0 is actually used:
`mvn dependency:tree -Dverbose -Dincludes=com.fasterxml.jackson.core:jackson-databind`