### PR TITLE
MODCAL-78: RMB 30.2.3, fixing pg_catalog.pg_trgm and sql injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <raml-module-builder.version>30.0.0</raml-module-builder.version>
+    <raml-module-builder.version>30.2.3</raml-module-builder.version>
     <vertx.version>3.9.0</vertx.version>
     <rest-assured.version>3.2.0</rest-assured.version>
     <aspectjrt.version>1.9.4</aspectjrt.version>


### PR DESCRIPTION
See https://issues.folio.org/browse/MODORDSTOR-161 . mod-calendar can fix
the pg_catalog.pg_trgm issue because it is the first upgraded module on
https://github.com/folio-org/platform-core/blob/q2-2020/install.json

CalendarIT.testGetCalendarPeriodsCalculateOpening() uses a service point id
that contains single quotes to test whether there are any SQL injection
issues. To fix these issues ActualOpeningHoursServiceImpl is changed to use
parameterized SQL queries with $1, $2, ... placeholders.