### PR TITLE
MODCAL-72 Disable char truncation for indexes

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -46,13 +46,17 @@
           "fieldName": "actualDay",
           "tOps": "ADD",
           "caseSensitive": true,
-          "removeAccents": false
+          "removeAccents": false,
+          "sqlExpression" : "(jsonb->>'actualDay')",
+          "sqlExpressionQuery": "$"
         },
         {
           "fieldName": "openingId",
           "tOps": "ADD",
           "caseSensitive": true,
-          "removeAccents": false
+          "removeAccents": false,
+          "sqlExpression" : "(jsonb->>'openingId')",
+          "sqlExpressionQuery": "$"
         }
       ]
     }


### PR DESCRIPTION
## Description
RMB is now truncating b-tree indexes to 600 characters. As a result, new indexes are not being picked up by Postgres when it runs queries in mod-calendar. 

Resolves: [MODCAL-72](https://issues.folio.org/browse/MODCAL-72)
## Approach
The truncating was disabled and now it exceeds maximum 2712 for index. 
'actualDay' contains Date and 'openingId' UUID value, so this means that such limit will not be achievable for these types of values.

