### PR TITLE
MODCAL-99 Upgrade to RMB 33.0.4 and Log4j 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <raml-module-builder.version>33.0.0</raml-module-builder.version>
+    <raml-module-builder.version>33.0.4</raml-module-builder.version>
     <vertx.version>4.1.0.CR1</vertx.version>
     <rest-assured.version>4.3.0</rest-assured.version>
     <aspectjrt.version>1.9.6</aspectjrt.version>


### PR DESCRIPTION
[MODCAL-99](https://issues.folio.org/browse/MODCAL-99)

Upgrade to RMB 33.0.4 which includes Log4j version with CVE-2021-44228 vulnerability fixed.