### PR TITLE
MODCAL-119: Spring Boot 2.7.5, folio-spring-base 5.0.2, … fix vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.7.5</version>
     <relativePath />
   </parent>
   <groupId>org.folio</groupId>
@@ -50,7 +50,7 @@
     <java.version>17</java.version>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <folio-spring-base.version>4.0.0</folio-spring-base.version>
+    <folio-spring-base.version>5.0.2</folio-spring-base.version>
     <openapi-generator.version>5.3.0</openapi-generator.version>
     <json.version>20200518</json.version>
     <lombok.version>1.18.22</lombok.version>
@@ -58,6 +58,8 @@
     <liquibase-maven-plugin.version>4.6.2</liquibase-maven-plugin.version>
     <javadoc-maven-plugin.version>3.3.1</javadoc-maven-plugin.version>
     <icu4j.version>70.1</icu4j.version>
+    <postgresql.version>42.5.0</postgresql.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
 
     <calendar-api-defintions-yaml-file>
       src/main/resources/api/calendar.yaml
@@ -66,7 +68,6 @@
     <!-- Test Properties-->
     <spring-boot-starter-test.version>2.6.6</spring-boot-starter-test.version>
     <wiremock.version>2.32.0</wiremock.version>
-    <rest-assured.version>4.4.0</rest-assured.version>
     <embedded-database-spring-test.version>2.1.1</embedded-database-spring-test.version>
     <swagger-request-validator.version>2.27.1</swagger-request-validator.version>
     <hamcrest-date-matcher.version>2.0.8</hamcrest-date-matcher.version>


### PR DESCRIPTION
Upgrade postgresql JDBC client from 42.3.3 to 42.5.0. This fixes SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-31197

Note that postgresql 42.3.* and 42.4.* have reached their end-of-life and should no longer be used in production: https://jdbc.postgresql.org/download/

Upgrade snakeyaml from 1.29 to 1.33 fixing Denial of Service (DoS) and Stack-based Buffer Overflow: https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749
https://nvd.nist.gov/vuln/detail/CVE-2022-38751
https://nvd.nist.gov/vuln/detail/CVE-2022-38752
https://nvd.nist.gov/vuln/detail/CVE-2022-41854

Upgrade rest-assured from 4.4.0 to 4.5.1 because Spring Boot uses rest-assured-bom that exists for 4.5.0 and later but not for 4.4.0.

Upgrade folio-spring-base from 4.0.0 (Morning Glory) to 5.0.2 (Nolana).

Upgrading folio-spring-base indirectly upgrades jackson-databind from 2.13.2.2 to 2.13.4.2 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrading folio-spring-base indirectly upgrades plexus-utils from 1.5.8 to 3.3.0 fixing Shell Command Injection and Directory Traversal and XML External Entity (XXE) Injection: https://nvd.nist.gov/vuln/detail/CVE-2017-1000487
https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521 https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102

Upgrading folio-spring-base indirectly upgrades okhttp from 3.14.9 to 4.9.3 fixing Information Exposure: https://app.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKHTTP3-2958044

Upgrading folio-spring-base indirectly upgrades commons-text from 1.9 to 1.10.0 fixing Arbitrary Code Execution: https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Upgrading folio-spring-base indirectly upgrades liquibase-core from 4.5.0 to 4.9.1 fixing XML External Entity (XXE) Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-0839

Upgrading folio-spring-base indirectly upgrades rhino from 1.7.7.2 to 1.7.14 fixing XML External Entity (XXE) Injection: https://app.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295

Upgrading folio-spring-base indirectly upgrades spring-context from 5.3.18 to 5.3.23 fixing Improper Handling of Case Sensitivity: https://nvd.nist.gov/vuln/detail/CVE-2022-22968

Upgrading folio-spring-base indirectly upgrades spring-security-crypto from 5.6.2 to 5.7.4 fixing Integer Overflow or Wraparound: https://nvd.nist.gov/vuln/detail/CVE-2022-22976

Upgrading folio-spring-base indirectly upgrades bcprov-jdk15on from 1.68 to 1.69 fixing Cryptographic Issues: https://app.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-2841508

Upgrading folio-spring-base indirectly upgrades spring-beans from 5.3.18 to 5.3.23 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2022-22970

Upgrading folio-spring-base indirectly upgrades tomcat-embed-core from 9.0.60 to 9.0.68 fixing HTTP Request Smuggling and Information Exposure: https://nvd.nist.gov/vuln/detail/CVE-2022-42252
https://nvd.nist.gov/vuln/detail/CVE-2021-43980

Upgrade Spring Boot from 2.6.6 to 2.7.5.

Note that Open Source support for Spring Boot 2.6.* ends 2022-11-24: https://spring.io/projects/spring-boot#support
Therefore upgrading to Spring Boot 2.7 is required for Nolana: https://wiki.folio.org/display/TC/Nolana

Upgrading Spring Boot indirectly upgrades spring-context from 5.3.18 to 5.3.23 fixing Improper Handling of Case Sensitivity: https://nvd.nist.gov/vuln/detail/CVE-2022-22968

Upgrading Spring Boot indirectly upgrades spring-security-crypto from 5.6.2 to 5.7.4 fixing Integer Overflow or Wraparound: https://nvd.nist.gov/vuln/detail/CVE-2022-22976