### PR TITLE
MODCAL-118: Remove remaining RMB functions 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2.2.0 2022-11-24
+* Remove leftover RMB functions (MODCAL-118)
+
 ## 2.1.0 2022-11-17
 * Update dependencies and folio-spring-base (MODCAL-119)
 

--- a/src/main/resources/db/changes/0060-drop-rmb-functions.yaml
+++ b/src/main/resources/db/changes/0060-drop-rmb-functions.yaml
@@ -1,0 +1,78 @@
+databaseChangeLog:
+  - changeSet:
+      id: 0060-drop-rmb-functions
+      author: university-of-alabama/ncovercash
+      comment: "Delete all previous RMB functions that have not been used since 2.0.0."
+      changes:
+        - sql:
+            sql: DROP FUNCTION IF EXISTS audit_openings_changes CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS audit_exceptional_hours_changes CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS concat_array_object CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS get_tsvector CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS tsquery_phrase(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS uuid_larger CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS next_uuid CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS count_estimate_default CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS audit_regular_hours_changes CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS rmb_internal_index CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_actual_opening_hours_md_json CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS normalize_digits CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_id_in_jsonb CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS first_array_object_value CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS concat_space_sql CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_openings_md_json CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS f_unaccent CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS tsquery_and(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS audit_actual_opening_hours_changes CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS exceptional_hours_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS audit_exceptions_changes CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS openings_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS concat_array_object_values CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_exceptional_hours_md_json CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS actual_opening_hours_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS uuid_smaller CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS tsquery_or(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS concat_array_object_values(jsonb,text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS concat_array_object_values(jsonb,text,text,text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS regular_hours_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS exceptions_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS upsert CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_exceptions_md_json CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS count_estimate CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_regular_hours_md_json CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS count_estimate_smart2 CASCADE;


### PR DESCRIPTION
These were missed as part of the initial upgrade to 2.0.0; these functions were unused.