### PR TITLE
MODCAL-120: Fix improper migration caused by regression in MODCAL-118

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2.3.0 IN PROGRESS
+* Fix module migration regression in 2.2.0 (MODCAL-120)
+
 ## 2.2.0 2022-11-24
 * Remove leftover RMB functions (MODCAL-118)
 

--- a/src/main/resources/db/changes/0060-drop-rmb-functions.yaml
+++ b/src/main/resources/db/changes/0060-drop-rmb-functions.yaml
@@ -5,74 +5,72 @@ databaseChangeLog:
       comment: "Delete all previous RMB functions that have not been used since 2.0.0."
       changes:
         - sql:
-            sql: DROP FUNCTION IF EXISTS audit_openings_changes CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS audit_exceptional_hours_changes CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS concat_array_object CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS get_tsvector CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS tsquery_phrase(text) CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS uuid_larger CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS next_uuid CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS count_estimate_default CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS audit_regular_hours_changes CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS rmb_internal_index CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS set_actual_opening_hours_md_json CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS normalize_digits CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS set_id_in_jsonb CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS first_array_object_value CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS concat_space_sql CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS set_openings_md_json CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS f_unaccent CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS tsquery_and(text) CASCADE;
+            sql: DROP FUNCTION IF EXISTS actual_opening_hours_set_md CASCADE;
         - sql:
             sql: DROP FUNCTION IF EXISTS audit_actual_opening_hours_changes CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS exceptional_hours_set_md CASCADE;
+            sql: DROP FUNCTION IF EXISTS audit_exceptional_hours_changes CASCADE;
         - sql:
             sql: DROP FUNCTION IF EXISTS audit_exceptions_changes CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS openings_set_md CASCADE;
+            sql: DROP FUNCTION IF EXISTS audit_openings_changes CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS concat_array_object_values CASCADE;
+            sql: DROP FUNCTION IF EXISTS audit_regular_hours_changes CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS set_exceptional_hours_md_json CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS actual_opening_hours_set_md CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS uuid_smaller CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS tsquery_or(text) CASCADE;
-        - sql:
-            sql: DROP FUNCTION IF EXISTS concat_array_object_values(jsonb,text) CASCADE;
+            sql: DROP FUNCTION IF EXISTS concat_array_object(jsonb) CASCADE;
         - sql:
             sql: DROP FUNCTION IF EXISTS concat_array_object_values(jsonb,text,text,text) CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS regular_hours_set_md CASCADE;
+            sql: DROP FUNCTION IF EXISTS concat_array_object_values(jsonb,text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS concat_space_sql(text[]) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS count_estimate(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS count_estimate_default(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS count_estimate_smart2(bigint,bigint,text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS exceptional_hours_set_md CASCADE;
         - sql:
             sql: DROP FUNCTION IF EXISTS exceptions_set_md CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS upsert CASCADE;
+            sql: DROP FUNCTION IF EXISTS f_unaccent(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS first_array_object_value(jsonb,text,text,text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS get_tsvector(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS next_uuid(uuid) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS normalize_digits(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS openings_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS regular_hours_set_md CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS rmb_internal_index(text,text,text,text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_actual_opening_hours_md_json CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_exceptional_hours_md_json CASCADE;
         - sql:
             sql: DROP FUNCTION IF EXISTS set_exceptions_md_json CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS count_estimate CASCADE;
+            sql: DROP FUNCTION IF EXISTS set_id_in_jsonb CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS set_openings_md_json CASCADE;
         - sql:
             sql: DROP FUNCTION IF EXISTS set_regular_hours_md_json CASCADE;
         - sql:
-            sql: DROP FUNCTION IF EXISTS count_estimate_smart2 CASCADE;
+            sql: DROP FUNCTION IF EXISTS tsquery_and(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS tsquery_or(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS tsquery_phrase(text) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS upsert(text,uuid,anyelement) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS uuid_larger(uuid,uuid) CASCADE;
+        - sql:
+            sql: DROP FUNCTION IF EXISTS uuid_smaller(uuid,uuid) CASCADE;


### PR DESCRIPTION
#152 did not fully qualify all function names to the necessary extent, causing errors on liquibase migration.  This PR fixes this issue and resolves the issues caused in 2.2.0.