### PR TITLE
MODCAL-125: Fix surrounding openings calculation edge case

### DIFF
--- a/src/test/java/org/folio/calendar/testconstants/Dates.java
+++ b/src/test/java/org/folio/calendar/testconstants/Dates.java
@@ -20,6 +20,7 @@ public class Dates {
   public static final LocalDate DATE_2021_01_07 = LocalDate.of(2021, Month.JANUARY, 7);
   public static final LocalDate DATE_2021_03_16 = LocalDate.of(2021, Month.MARCH, 16);
   public static final LocalDate DATE_2021_03_18 = LocalDate.of(2021, Month.MARCH, 18);
+  public static final LocalDate DATE_2021_04_29 = LocalDate.of(2021, Month.APRIL, 29);
   public static final LocalDate DATE_2021_04_30 = LocalDate.of(2021, Month.APRIL, 30);
   public static final LocalDate DATE_2021_05_01 = LocalDate.of(2021, Month.MAY, 1);
   public static final LocalDate DATE_2021_05_03 = LocalDate.of(2021, Month.MAY, 3);

--- a/src/test/java/org/folio/calendar/unit/utils/CalendarUtilsSurroundingOpeningsTest.java
+++ b/src/test/java/org/folio/calendar/unit/utils/CalendarUtilsSurroundingOpeningsTest.java
@@ -473,4 +473,63 @@ class CalendarUtilsSurroundingOpeningsTest {
       )
     );
   }
+
+  @Test
+  void testOnStartingEdgeBetweenAdjacentCalendars() {
+    List<SingleDayOpeningDTO> openings = CalendarUtils
+      .getSurroundingOpenings(
+        Arrays.asList(Calendars.CALENDAR_FULL_EXAMPLE_E, Calendars.CALENDAR_FULL_EXAMPLE_D),
+        Dates.DATE_2021_05_01
+      )
+      .getOpenings();
+
+    assertThat(openings, hasSize(3));
+    assertThat(
+      openings,
+      contains(
+        SingleDayOpeningDTO
+          .builder()
+          .date(Dates.DATE_2021_04_29)
+          .open(true)
+          .allDay(true)
+          .opening(
+            SingleDayOpeningRangeDTO
+              .builder()
+              .startTime(Times.TIME_00_00)
+              .endTime(Times.TIME_23_59)
+              .build()
+          )
+          .exceptional(false)
+          .build(),
+        SingleDayOpeningDTO
+          .builder()
+          .date(Dates.DATE_2021_05_01)
+          .open(false)
+          .allDay(true)
+          .exceptional(false)
+          .build(),
+        SingleDayOpeningDTO
+          .builder()
+          .date(Dates.DATE_2021_05_03)
+          .open(true)
+          .allDay(false)
+          .opening(
+            SingleDayOpeningRangeDTO
+              .builder()
+              .startTime(Times.TIME_00_00)
+              .endTime(Times.TIME_12_30)
+              .build()
+          )
+          .opening(
+            SingleDayOpeningRangeDTO
+              .builder()
+              .startTime(Times.TIME_23_00)
+              .endTime(Times.TIME_23_59)
+              .build()
+          )
+          .exceptional(false)
+          .build()
+      )
+    );
+  }
 }


### PR DESCRIPTION
# [Jira](https://issues.folio.org/browse/MODCAL-125)

Under proper circumstances, a request to /calendar/dates/{servicePointId}/surrounding-openings would result in a 500 error with an exception stating that the "key is out of range".

This was due to a logical fault in the CalendarUtils class; when calculating the previous and next openings, sublists of a larger TreeMap were used, however, these sublists had a hard limit on their upper/lower bounds.  Therefore, when slicing calendars into individual dates to fill this map, it was possible for the code to attempt to insert a date which was out of the map's range (therefore on the wrong side of the requested date, making it irrelevant to the query, but still throwing an exception).  This was resolved by adding an extra filter to ensure only necessary dates were considered.

