### PR TITLE
[MODCAL-134] Increase default memory

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -151,7 +151,7 @@
     "dockerPull": false,
     "dockerArgs": {
       "HostConfig": {
-        "Memory": 314572800,
+        "Memory": 514572800,
         "PortBindings": { "8081/tcp": [{ "HostPort": "%p" }] }
       }
     },


### PR DESCRIPTION
mod-calendar occasionally runs out of memory in snapshot, resulting in OOM kills. This adds 200 mb as a precaution against this.