### PR TITLE
[MODCAL-135] Disable server-side caching of prepared queries to handle recreated DBs on the fly

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,7 +11,7 @@ spring:
   datasource:
     username: ${DB_USERNAME:postgres}
     password: ${DB_PASSWORD:postgres}
-    url: jdbc:postgresql://${DB_HOST:postgres}:${DB_PORT:5432}/${DB_DATABASE:okapi_modules}?stringtype=unspecified
+    url: jdbc:postgresql://${DB_HOST:postgres}:${DB_PORT:5432}/${DB_DATABASE:okapi_modules}?stringtype=unspecified&autosave=always&cleanupSavepoints=true&prepareThreshold=0&preparedStatementCacheQueries=0
   jpa:
     show-sql: false
     hibernate:


### PR DESCRIPTION
# [Jira MODCAL-135](https://folio-org.atlassian.net/browse/MODCAL-135)

## The issue

The module can fail to insert sample calendars if the database is quickly created, dropped, and created again in quick succession (less than a few seconds).

## The reproduction

```sh
# install
curl --request POST \
  --url http://localhost:8081/_/tenant \
  --header 'content-type: application/json' \
  --header 'x-okapi-tenant: something' \
  --data '{ "module_to": "foo", "parameters": [{"key": "loadReference","value": "true"},{"key": "loadSample","value": "true"}]}'

# remove and purge
curl --request POST \
  --url http://localhost:8081/_/tenant \
  --header 'content-type: application/json' \
  --header 'x-okapi-tenant: something' \
  --data '{ "module_from": "foo", "purge": true }'

# install again
curl --request POST \
  --url http://localhost:8081/_/tenant \
  --header 'x-okapi-tenant: something' \
  --header 'content-type: application/json' \
  --data '{ "module_to": "foo", "parameters": [{"key": "loadReference","value": "true"},{"key": "loadSample","value": "true"}]}'
```

## The unintended behavior

One of two cases occurred, depending on how quickly the race condition is triggered:

#### Table cannot be found

```
SQL Error: 0, SQLState: 42P01
ERROR: relation "calendars" does not exist
  Position: 145
org.springframework.dao.InvalidDataAccessResourceUsageException: JDBC exception executing SQL [select c1_0.id,c1_0.created_by_user_id,c1_0.created_date,c1_0.end_date,c1_0.name,c1_0.start_date,c1_0.updated_by_user_id,c1_0.updated_date from calendars c1_0 join service_point_calendars spca1_0 on c1_0.id=spca1_0.calendar_id where (spca1_0.service_point_id in (?)) and (cast(? as date) is null or c1_0.end_date>=?) and (cast(? as date) is null or c1_0.start_date<=?) order by c1_0.start_date]
  [ERROR: relation "calendars" does not exist Position: 145] [n/a]; SQL [n/a]
```

_This one may take numerous runs of the reproduction to trigger, and likely may occur with any of the other tables, too_

#### cache lookup failed for type failed (original error)

```
SQL Error: 0, SQLState: XX000
ERROR: cache lookup failed for type 20754
org.springframework.orm.jpa.JpaSystemException: could not execute statement [ERROR: cache lookup failed for type 20754] [insert into normal_hours (calendar_id,end_day,end_time,start_day,start_time,id) values (?,?,?,?,?,?)]
```

## The cause

These errors occur if the original sample calendars (or hours) were inserted recently enough for their information to still be cached (either the table's existence as a whole, or the special enum type `weekday` (used for `start_day` and `end_day` columns in` normal_hours`). The postgresql database driver, `pgjdbc`, caches some of this information internally and/or on the server, for optimization purposes.

## The fix (short term)

This PR adds three parameters to the JDBC connection (available ones are documented [here](https://jdbc.postgresql.org/documentation/use/)):

### `autosave=always`

This controls what the driver should do in the case of failure. Three options are available:

- `autosave=always` sets a savepoint before each query, and rolls back to that savepoint in case of failure
- `autosave=never` (default) never makes any savepoints
- `autosave=conservative` sets a savepoint for each query, however the rollback is done only for rare cases like ‘cached statement cannot change return type’ or ‘statement XXX is not valid’ so JDBC driver rolls back and retries

Ideally, we would be able to use `autosave=conservative`, however, this only handles some cases, not each of ours as listed above. There is a similar ticket in `pgjdbc` to resolve this and similar issues: https://github.com/pgjdbc/pgjdbc/issues/1786 (for functions, at least). Ideally, once the ticket is resolved, we can likely get away with `autosave=conservative` instead of `always`, but that will require future investigation.

### `prepareThreshold=0`, `preparedStatementCacheQueries=0`

The other issue, where it cannot find the `calendars` table, is due to prepared statements being cached on the server. The driver/server, by default, will begin caching prepared statements that are ran more than five times (`prepareThreshold`), storing the last 256 queries (`preparedStatementCacheQueries`). This causes an issue, though, when the tables are dropped and recreated, as the prepared and cached query refers to a table that no longer exists.

We set these to zero to prevent this from happening, ever.

### Performance?

Benchmarks completed by [various users](https://stackoverflow.com/a/48536394/4236490) show minimal, if any, additional overhead here. The use cases for this module to not typically involve heavy demand of creating/editing calendars, so I forsee no impact from these changes.

## The ideal solution

Aside from stopgaps in the Postgres driver itself, I believe we should find a way to "reset" the postgres connection/datasource whenever a tenant is destroyed inside of https://github.com/folio-org/folio-spring-support, as this is likely not just a potential issue with the calendar module (although other spring modules may have more installation logic, and thus take too long to trigger this race condition).

## Should this be copied in other modules?

Probably not. Other modules may see some performance issues, and this is a hacky fix, at best. It'd be much better long-term for the ideal solution above to be implemented so that all Spring modules can benefit universally without any additional hassle or configuration.