### PR TITLE
MODCAL-136: Fixed Module Descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -39,12 +39,12 @@
         {
           "methods": ["GET"],
           "pathPattern": "/calendar/dates/{servicePointId}/surrounding-openings",
-          "permissionsRequired": ["calendar.endpoint.dates.get"]
+          "permissionsRequired": ["calendar.endpoint.calendars.surroundingOpenings.get"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/calendar/dates/{servicePointId}/all-openings",
-          "permissionsRequired": ["calendar.endpoint.dates.get"]
+          "permissionsRequired": ["calendar.endpoint.calendars.allOpenings.get"]
         }
       ]
     },
@@ -105,6 +105,18 @@
     {
       "permissionName": "calendar.endpoint.calendars.get",
       "displayName": "Make GET requests to /calendar/calendars",
+      "description": "",
+      "visible": false
+    },
+    {
+      "permissionName": "calendar.endpoint.calendars.surroundingOpenings.get",
+      "displayName": "Make GET requests to /calendar/dates/{servicePointID}/surrounding-openings",
+      "description": "",
+      "visible": false
+    },
+    {
+      "permissionName": "calendar.endpoint.calendars.allOpenings.get",
+      "displayName": "Make GET requests to /calendar/dates/{servicePointId}/all-openings",
       "description": "",
       "visible": false
     },

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,14 @@
   <name>mod-calendar</name>
   <description>FOLIO calendar module for service point openings</description>
 
+  <pluginRepositories>
+    <pluginRepository>
+      <id>folio-nexus</id>
+      <name>FOLIO Maven repository</name>
+      <url>https://repository.folio.org/repository/maven-folio</url>
+    </pluginRepository>
+  </pluginRepositories>
+
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -453,6 +461,19 @@
             <phase>pre-site</phase>
             <goals>
               <goal>javadoc</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Added Module Descriptor error checker to pom.xml file and applied changes to the module descriptor based on the errors detected. See [MODCAL-136](https://folio-org.atlassian.net/issues/MODCAL-136?jql=ORDER%20BY%20created%20DESC) for relevant links and error checker implementation/usage.