### PR TITLE
[FOLIO-4249] Update to Java 21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk17:latest
+FROM folioci/alpine-jre-openjdk21:latest
 
 # Copy your fat jar to the container
 ENV APP_FILE mod-calendar-fat.jar

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ buildMvn {
   publishModDescriptor = true
   mvnDeploy = true
   doUploadApidocs = true
-  buildNode = 'jenkins-agent-java17'
+  buildNode = 'jenkins-agent-java21'
 
   doDocker = {
     buildDocker {

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 3.3.0 IN PROGRESS
+* Update to Java v21 ([FOLIO-4249](https://folio-org.atlassian.net/browse/FOLIO-4249))
+
 ## 3.2.0 2024-11-04
 * Translation updates
 * Increase default memory ([MODCAL-134](https://folio-org.atlassian.net/browse/MODCAL-134))

--- a/docs/database-schema.md
+++ b/docs/database-schema.md
@@ -69,10 +69,3 @@ In order to invoke liquibase directly, you may use the Maven goal `liquibase:upd
 file specifies the default Okapi database credentials in order to upgrade `diku`'s installation;
 other tenants/setups can be specified by editing this, `pom.xml`, or adding command-line options to
 Maven.
-
-## Test Environment
-
-In the test environment, a real Postgres database is not used (to ensure this is fully separate from
-anything else). Instead, an
-[isolated test database](https://github.com/zonkyio/embedded-database-spring-test) is used, and the
-`/_/tenant` route is used to ensure this is initialized properly.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -67,12 +69,13 @@
 
     <!-- Test Properties-->
     <wiremock.version>3.4.2</wiremock.version>
-    <embedded-database-spring-test.version>2.5.0</embedded-database-spring-test.version>
+    <embedded-database-spring-test.version>2.6.0</embedded-database-spring-test.version>
     <swagger-request-validator.version>2.40.0</swagger-request-validator.version>
     <hamcrest-date-matcher.version>2.0.8</hamcrest-date-matcher.version>
     <hamcrest-optional.version>2.0.0</hamcrest-optional.version>
     <jacoco-maven-plugin.version>0.8.11</jacoco-maven-plugin.version>
     <mapstruct.version>1.5.5.Final</mapstruct.version>
+    <testcontainers.version>1.20.5</testcontainers.version>
   </properties>
 
   <dependencies>
@@ -150,16 +153,16 @@
     </dependency>
 
     <dependency>
-      <groupId>io.zonky.test</groupId>
-      <artifactId>embedded-database-spring-test</artifactId>
-      <version>${embedded-database-spring-test.version}</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>${testcontainers.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -55,10 +55,8 @@
   </distributionManagement>
 
   <properties>
-    <java.version>17</java.version>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
-    <folio-spring.version>8.1.0</folio-spring.version>
+    <java.version>21</java.version>
+    <folio-spring.version>9.0.0</folio-spring.version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
     <icu4j.version>74.2</icu4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.3</version>
+    <version>3.4.3</version>
     <relativePath />
   </parent>
   <groupId>org.folio</groupId>
@@ -58,7 +58,7 @@
     <java.version>21</java.version>
     <folio-spring.version>9.0.0</folio-spring.version>
     <openapi-generator.version>7.3.0</openapi-generator.version>
-    <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
+    <lombok-maven-plugin.version>1.18.36</lombok-maven-plugin.version>
     <icu4j.version>74.2</icu4j.version>
 
     <calendar-api-defintions-yaml-file>

--- a/src/main/java/org/folio/calendar/controller/ApiExceptionHandler.java
+++ b/src/main/java/org/folio/calendar/controller/ApiExceptionHandler.java
@@ -131,8 +131,7 @@ public class ApiExceptionHandler {
    */
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ErrorResponseDTO> handleAllOtherExceptions(Exception exception) {
-    log.error(exception);
-    log.error(exception.getMessage());
+    log.error("Unknown exception:", exception);
 
     // As a note, NullPointerException can be thrown deep in the servlet code if parsing invalid JSON.
     // However, NPE is far too generic to catch and always attribute to bad input.

--- a/src/main/java/org/folio/calendar/controller/CalendarController.java
+++ b/src/main/java/org/folio/calendar/controller/CalendarController.java
@@ -52,7 +52,7 @@ public class CalendarController implements CalendarApi {
     log.info("createCalendar: Calendar passed validation, saving...");
 
     calendar.clearIds();
-    calendar.setId(UUID.randomUUID());
+    calendar.setId(null);
 
     calendar.setCreatedDate(Instant.now());
     calendar.setUpdatedDate(Instant.now());

--- a/src/main/java/org/folio/calendar/domain/entity/Calendar.java
+++ b/src/main/java/org/folio/calendar/domain/entity/Calendar.java
@@ -4,6 +4,7 @@ import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.PrePersist;
@@ -39,7 +40,7 @@ public class Calendar implements Serializable {
    * The UUID of the calendar
    */
   @Id
-  @NotNull
+  @GeneratedValue
   @Column(name = "id")
   private UUID id;
 
@@ -127,14 +128,6 @@ public class Calendar implements Serializable {
   @CheckForNull
   @Column(name = "updated_by_user_id")
   private UUID updatedByUserId;
-
-  // provide default random ID when another is not specified
-  // SonarLint does not like that this is unused; lombok provides the builder implementation
-  @SuppressWarnings("java:S1068")
-  public static class CalendarBuilder {
-
-    private UUID id = UUID.randomUUID();
-  }
 
   @PreUpdate
   @PrePersist

--- a/src/main/java/org/folio/calendar/domain/sample/SampleCalendars.java
+++ b/src/main/java/org/folio/calendar/domain/sample/SampleCalendars.java
@@ -86,7 +86,6 @@ public class SampleCalendars {
   ) {
     return Calendar
       .builder()
-      .id(UUID.randomUUID())
       .name(String.format("Circ Desk 1 %s Hours", lastMonthName))
       .startDate(lastMonthStart)
       .endDate(lastMonthEnd)
@@ -117,7 +116,6 @@ public class SampleCalendars {
       .exception(
         ExceptionRange
           .builder()
-          .id(UUID.randomUUID())
           .startDate(lastMonthStart.plusDays(1))
           .endDate(lastMonthStart.plusDays(1))
           .build()
@@ -133,7 +131,6 @@ public class SampleCalendars {
   ) {
     return Calendar
       .builder()
-      .id(UUID.randomUUID())
       .name(String.format("Circ Desk 1 %s-%s Hours", thisMonthName, nextMonthName))
       .startDate(thisMonthStart)
       .endDate(nextMonthEnd)
@@ -209,7 +206,6 @@ public class SampleCalendars {
       .exception(
         ExceptionRange
           .builder()
-          .id(UUID.randomUUID())
           .startDate(thisMonthStart.plusDays(1))
           .endDate(thisMonthStart.plusDays(LONG_EXCEPTION_LENGTH))
           .opening(
@@ -229,7 +225,6 @@ public class SampleCalendars {
   protected Calendar getServicePointTwoCalendar(LocalDate nextMonthStart, LocalDate nextMonthEnd) {
     return Calendar
       .builder()
-      .id(UUID.randomUUID())
       .name("Limited Opening Sample")
       .startDate(nextMonthStart)
       .endDate(nextMonthEnd)
@@ -272,7 +267,6 @@ public class SampleCalendars {
   protected Calendar getOnlineCalendar(LocalDate lastMonthStart, LocalDate nextMonthEnd) {
     return Calendar
       .builder()
-      .id(UUID.randomUUID())
       .name("24/7 Online Access")
       .startDate(lastMonthStart)
       .endDate(nextMonthEnd)

--- a/src/main/java/org/folio/calendar/utils/PeriodUtils.java
+++ b/src/main/java/org/folio/calendar/utils/PeriodUtils.java
@@ -6,7 +6,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
@@ -51,11 +50,8 @@ public class PeriodUtils {
    * @return the corresponding {@code ExceptionRange}
    */
   public static ExceptionRange convertExceptionalPeriodToExceptionRanges(PeriodDTO period) {
-    UUID exceptionId = UUID.randomUUID();
-
     ExceptionRangeBuilder builder = ExceptionRange
       .builder()
-      .id(exceptionId)
       .name(period.getName())
       .startDate(period.getStartDate().getValue())
       .endDate(period.getEndDate().getValue());

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,8 +18,6 @@ spring:
       ddl-auto: none
   banner:
     location: classpath:/banner.txt
-  mvc:
-    throw-exception-if-no-handler-found: true
   web:
     resources:
       add-mappings: false

--- a/src/test/java/org/folio/calendar/integration/BaseApiAutoDatabaseTest.java
+++ b/src/test/java/org/folio/calendar/integration/BaseApiAutoDatabaseTest.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import javax.sql.DataSource;
 import lombok.extern.log4j.Log4j2;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,18 +18,9 @@ public abstract class BaseApiAutoDatabaseTest extends BaseApiTest {
 
   protected boolean hasCreated = false;
 
-  @AfterAll
-  void afterAll(TestInfo testInfo, @Autowired DataSource dataSource) {
-    if (testInfo.getTags().contains("idempotent")) {
-      cleanDatabase(dataSource);
-    }
-  }
-
   @AfterEach
   void afterEach(TestInfo testInfo, @Autowired DataSource dataSource) {
-    if (!testInfo.getTags().contains("idempotent")) {
-      cleanDatabase(dataSource);
-    }
+    cleanDatabase(dataSource);
   }
 
   protected void cleanDatabase(@Autowired DataSource dataSource) {

--- a/src/test/java/org/folio/calendar/integration/BaseApiAutoDatabaseTest.java
+++ b/src/test/java/org/folio/calendar/integration/BaseApiAutoDatabaseTest.java
@@ -5,7 +5,6 @@ import java.sql.SQLException;
 import javax.sql.DataSource;
 import lombok.extern.log4j.Log4j2;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.TestInfo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
@@ -19,7 +18,7 @@ public abstract class BaseApiAutoDatabaseTest extends BaseApiTest {
   protected boolean hasCreated = false;
 
   @AfterEach
-  void afterEach(TestInfo testInfo, @Autowired DataSource dataSource) {
+  void afterEach(@Autowired DataSource dataSource) {
     cleanDatabase(dataSource);
   }
 

--- a/src/test/java/org/folio/calendar/integration/BaseApiTest.java
+++ b/src/test/java/org/folio/calendar/integration/BaseApiTest.java
@@ -13,8 +13,6 @@ import io.restassured.http.Header;
 import io.restassured.path.json.config.JsonPathConfig;
 import io.restassured.specification.ProxySpecification;
 import io.restassured.specification.RequestSpecification;
-import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
-import io.zonky.test.db.AutoConfigureEmbeddedDatabase.RefreshMode;
 import java.util.Locale;
 import lombok.Getter;
 import lombok.Setter;
@@ -46,7 +44,6 @@ import org.springframework.test.context.ContextConfiguration;
 @Log4j2
 @ActiveProfiles("test")
 @TestInstance(Lifecycle.PER_CLASS)
-@AutoConfigureEmbeddedDatabase(refresh = RefreshMode.NEVER)
 @ContextConfiguration(initializers = { WireMockInitializer.class })
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class BaseApiTest {

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -8,14 +8,14 @@ spring:
   liquibase:
     enabled: true
     change-log: classpath:db/changelog-master.yaml
+  datasource:
+    url: jdbc:tc:postgresql:16-alpine:///db?stringtype=unspecified
   jpa:
     show-sql: false
     hibernate:
       ddl-auto: none
   banner:
     location: classpath:/banner.txt
-  mvc:
-    throw-exception-if-no-handler-found: true
   web:
     resources:
       add-mappings: false
@@ -23,16 +23,6 @@ spring:
     openfeign:
       okhttp:
         enabled: true
-
-zonky:
-  test:
-    database:
-      postgres:
-        docker:
-          image: ${TESTCONTAINERS_POSTGRES_IMAGE:postgres:12-alpine}
-        client:
-          properties:
-            stringtype: unspecified
 
 management:
   endpoints:


### PR DESCRIPTION
# [Jira FOLIO-4249](https://folio-org.atlassian.net/browse/FOLIO-4249)

This updates Java from 17 to 21. As part of this, we had to:
1. Update Spring and friends
1. Change our embedded database architecture for integration tests, due to incompatibility with later Spring/Hibernate
1. Ensure Hibernate is the only one generating entity IDs, to go with new behavior introduced in part of our updates